### PR TITLE
Add parameters to be compatible with Contao 4.6

### DIFF
--- a/src/DependencyInjection/MultiColumnWizardExtension.php
+++ b/src/DependencyInjection/MultiColumnWizardExtension.php
@@ -51,7 +51,9 @@ class MultiColumnWizardExtension extends ConfigurableExtension
 
         return new Configuration(
             $container->getParameter('kernel.debug'),
-            $container->getParameter('kernel.project_dir')
+            $container->getParameter('kernel.project_dir'),
+            $container->getParameter('kernel.root_dir'),
+            $container->getParameter('kernel.default_locale')
         );
     }
 


### PR DESCRIPTION
In the latest Contao version, these four parameters are required by the constructor.