### PR TITLE
Cast the data to array.

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -419,6 +419,8 @@ class MultiColumnWizard extends Widget implements \uploadable
      */
     protected function validator($varInput)
     {
+        $varInput = (array) $varInput;
+        
         // The order of the data are in the right order. So just catch it and save it.
         $sortOrder = [];
         $sortId    = 0;


### PR DESCRIPTION
`$varInput` might be `null`, however, the code is constructed to expect an array.
* Array access with `$varInput[$i]`
* `\array_keys($varInput)` --> results in `Invalid argument supplied for foreach()`
* `count($varInput)` --> provokes error since PHP 7.2