### PR TITLE
hotfix empty headline

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -1342,7 +1342,7 @@ class MultiColumnWizard extends Widget
                 $this->strId
             );
 
-            if ($this->columnTemplate == '') {
+            if ($this->columnTemplate == '' && is_array($arrHeaderItems)) {
                 $return .= \sprintf('<thead><tr>%s<th></th></tr></thead>', implode("\n      ", $arrHeaderItems));
             }
 


### PR DESCRIPTION
hotfix empty headline to fix warning in symfony toolbar