### PR TITLE
Fix post ajax contao name changes

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -25,6 +25,7 @@
  * @author     Gerald Meier <garyee@gmx.de>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Jozef Dvorský <creatingo@users.noreply.github.com>
+ * @author     Julian Aziz Haslinger <me@aziz.wtf>
  * @author     Kester Mielke <kester.mieke@gmx.net>
  * @author     mediabakery <s.tilch@mediabakery.de>
  * @author     Oliver Hoff <oliver@hofff.com>
@@ -465,7 +466,7 @@ class MultiColumnWizard extends Widget
         // Return the result.
         return $event->getWizard();
     }
-    
+
     /**
      * Try to get the DC Drive.
      * For the DCG we have to handel the HTTP_X_REQUESTED_WITH, to cancel an endless loop.
@@ -819,6 +820,14 @@ class MultiColumnWizard extends Widget
                         $objWidget->parse(),
                         implode('', $additionalCode)
                     );
+                }
+
+                // Contao changed the name for FileTree and PageTree widgets @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
+                if((version_compare(VERSION, '4.4.41', '>=') &&
+                    version_compare(VERSION, '4.5.0', '<')) ||
+                   version_compare(VERSION, '4.7.7', '>=')) {
+                    $strWidget = str_replace(['reloadFiletree', 'reloadFiletreeDMA'], 'reloadFiletree_mcw', $strWidget);
+                    $strWidget = str_replace(['reloadPagetree', 'reloadPagetreeDMA'], 'reloadPagetree_mcw', $strWidget);
                 }
 
                 // Build array of items

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -824,9 +824,10 @@ class MultiColumnWizard extends Widget
 
                 // Contao changed the name for FileTree and PageTree widgets
                 // @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
-                if ((version_compare(VERSION, '4.4.41', '>=') &&
-                    version_compare(VERSION, '4.5.0', '<')) ||
-                   version_compare(VERSION, '4.7.7', '>=')) {
+                $contaoVersion = VERSION.'.'.BUILD;
+                if ((version_compare($contaoVersion, '4.4.41', '>=') &&
+                    version_compare($contaoVersion, '4.5.0', '<')) ||
+                   version_compare($contaoVersion, '4.7.7', '>=')) {
                     $strWidget = str_replace(['reloadFiletree', 'reloadFiletreeDMA'], 'reloadFiletree_mcw', $strWidget);
                     $strWidget = str_replace(['reloadPagetree', 'reloadPagetreeDMA'], 'reloadPagetree_mcw', $strWidget);
                 }

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -822,8 +822,9 @@ class MultiColumnWizard extends Widget
                     );
                 }
 
-                // Contao changed the name for FileTree and PageTree widgets @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
-                if((version_compare(VERSION, '4.4.41', '>=') &&
+                // Contao changed the name for FileTree and PageTree widgets
+                // @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
+                if ((version_compare(VERSION, '4.4.41', '>=') &&
                     version_compare(VERSION, '4.5.0', '<')) ||
                    version_compare(VERSION, '4.7.7', '>=')) {
                     $strWidget = str_replace(['reloadFiletree', 'reloadFiletreeDMA'], 'reloadFiletree_mcw', $strWidget);

--- a/src/EventListener/Contao/ExecutePostActions.php
+++ b/src/EventListener/Contao/ExecutePostActions.php
@@ -157,13 +157,14 @@ class ExecutePostActions extends BaseListener
 
         $intId    = \Input::get('id');
         $strField = $container->inputName = \Input::post('name');
-        // Contao changed the name for FileTree and PageTree widgets @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
+        // Contao changed the name for FileTree and PageTree widgets
+        // @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
         $vNameCheck = (version_compare(VERSION, '4.4.41', '>=') &&
                        version_compare(VERSION, '4.5.0', '<')) ||
                       version_compare(VERSION, '4.7.7', '>=');
 
-        if($vNameCheck) {
-            $fieldParts       = preg_split("/[\[,]|[]\[,]+/", $strField);
+        if ($vNameCheck) {
+            $fieldParts       = preg_split('/[\[,]|[]\[,]+/', $strField);
             $container->field = $strField;
             $mcwBaseName      = $fieldParts[0];
             $intRow           = $fieldParts[1];
@@ -184,7 +185,7 @@ class ExecutePostActions extends BaseListener
 
         // Handle the keys in "edit multiple" mode
         if (\Input::get('act') == 'editAll') {
-            if($vNameCheck) {
+            if ($vNameCheck) {
                 $intId = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $mcwBaseName);
                 $mcwBaseName = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $mcwBaseName);
             } else {
@@ -301,7 +302,7 @@ class ExecutePostActions extends BaseListener
         $objWidget = new $strClass($fieldAttributes);
         $strWidget = $objWidget->generate();
 
-        if($vNameCheck) {
+        if ($vNameCheck) {
             $strWidget = str_replace(['reloadFiletree', 'reloadFiletreeDMA'], 'reloadFiletree_mcw', $strWidget);
             $strWidget = str_replace(['reloadPagetree', 'reloadPagetreeDMA'], 'reloadPagetree_mcw', $strWidget);
         }

--- a/src/EventListener/Contao/ExecutePostActions.php
+++ b/src/EventListener/Contao/ExecutePostActions.php
@@ -12,6 +12,7 @@
  *
  * @package    menatwork/contao-multicolumnwizard-bundle
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Julian Aziz Haslinger <me@aziz.wtf>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @copyright  2011 Andreas Schempp
  * @copyright  2011 certo web & design GmbH
@@ -156,24 +157,41 @@ class ExecutePostActions extends BaseListener
 
         $intId    = \Input::get('id');
         $strField = $container->inputName = \Input::post('name');
+        // Contao changed the name for FileTree and PageTree widgets @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
+        $vNameCheck = (version_compare(VERSION, '4.4.41', '>=') &&
+                       version_compare(VERSION, '4.5.0', '<')) ||
+                      version_compare(VERSION, '4.7.7', '>=');
 
-        // Get the field name parts.
-        $fieldParts = preg_split('/_row[0-9]*_/i', $strField);
-        preg_match('/_row[0-9]*_/i', $strField, $arrRow);
-        $intRow = substr(substr($arrRow[0], 4), 0, -1);
+        if($vNameCheck) {
+            $fieldParts       = preg_split("/[\[,]|[]\[,]+/", $strField);
+            $container->field = $strField;
+            $mcwBaseName      = $fieldParts[0];
+            $intRow           = $fieldParts[1];
+            $mcwSupFieldName  = $fieldParts[2];
+        } else {
+            // Get the field name parts.
+            $fieldParts = preg_split('/_row[0-9]*_/i', $strField);
+            preg_match('/_row[0-9]*_/i', $strField, $arrRow);
+            $intRow = substr(substr($arrRow[0], 4), 0, -1);
 
-        // Rebuild field name.
-        $mcwFieldName    = $fieldParts[0] . '[' . $intRow . '][' . $fieldParts[1] . ']';
-        $mcwBaseName     = $fieldParts[0];
-        $mcwSupFieldName = $fieldParts[1];
+            // Rebuild field name.
+            $container->field = $fieldParts[0] . '[' . $intRow . '][' . $fieldParts[1] . ']';
+            $mcwBaseName      = $fieldParts[0];
+            $mcwSupFieldName  = $fieldParts[1];
+        }
+
+        $mcwId = $mcwBaseName . '_row' . $intRow . '_' . $mcwSupFieldName;
 
         // Handle the keys in "edit multiple" mode
         if (\Input::get('act') == 'editAll') {
-            $intId    = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $strField);
-            $strField = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $strField);
+            if($vNameCheck) {
+                $intId = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $mcwBaseName);
+                $mcwBaseName = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $mcwBaseName);
+            } else {
+                $intId    = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $strField);
+                $strField = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $strField);
+            }
         }
-
-        $container->field = $mcwFieldName;
 
         // Add the sub configuration into the DCA. We need this for contao. Without it is not possible
         // to get the data for the picker.
@@ -273,15 +291,21 @@ class ExecutePostActions extends BaseListener
             $container
         );
 
-        $fieldAttributes['id']       = \Input::post('name');
-        $fieldAttributes['name']     = $mcwFieldName;
+        $fieldAttributes['id']       = $mcwId;
+        $fieldAttributes['name']     = $container->field;
         $fieldAttributes['value']    = $varValue;
         $fieldAttributes['strTable'] = $container->table;
         $fieldAttributes['strField'] = $strField;
 
         /** @var FileTree|PageTree $objWidget */
         $objWidget = new $strClass($fieldAttributes);
+        $strWidget = $objWidget->generate();
 
-        throw new ResponseException($this->convertToResponse($objWidget->generate()));
+        if($vNameCheck) {
+            $strWidget = str_replace(['reloadFiletree', 'reloadFiletreeDMA'], 'reloadFiletree_mcw', $strWidget);
+            $strWidget = str_replace(['reloadPagetree', 'reloadPagetreeDMA'], 'reloadPagetree_mcw', $strWidget);
+        }
+
+        throw new ResponseException($this->convertToResponse($strWidget));
     }
 }

--- a/src/EventListener/Contao/ExecutePostActions.php
+++ b/src/EventListener/Contao/ExecutePostActions.php
@@ -159,9 +159,10 @@ class ExecutePostActions extends BaseListener
         $strField = $container->inputName = \Input::post('name');
         // Contao changed the name for FileTree and PageTree widgets
         // @see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51
-        $vNameCheck = (version_compare(VERSION, '4.4.41', '>=') &&
-                       version_compare(VERSION, '4.5.0', '<')) ||
-                      version_compare(VERSION, '4.7.7', '>=');
+        $contaoVersion = VERSION . '.' . BUILD;
+        $vNameCheck    = (version_compare($contaoVersion, '4.4.41', '>=') &&
+                          version_compare($contaoVersion, '4.5.0', '<')) ||
+                         version_compare($contaoVersion, '4.7.7', '>=');
 
         if ($vNameCheck) {
             $fieldParts       = preg_split('/[\[,]|[]\[,]+/', $strField);

--- a/src/EventListener/Contao/ExecutePostActions.php
+++ b/src/EventListener/Contao/ExecutePostActions.php
@@ -186,7 +186,7 @@ class ExecutePostActions extends BaseListener
         // Handle the keys in "edit multiple" mode
         if (\Input::get('act') == 'editAll') {
             if ($vNameCheck) {
-                $intId = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $mcwBaseName);
+                $intId       = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $mcwBaseName);
                 $mcwBaseName = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $mcwBaseName);
             } else {
                 $intId    = preg_replace('/.*_([0-9a-zA-Z]+)$/', '$1', $strField);


### PR DESCRIPTION
I found a workaround for the contao FileTree and PageTree widgets changes from https://github.com/contao/contao/commit/279f94c74d820b8717a2e7a7672e67786646563e

Issue: https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/51#issuecomment-539605216

I test it on Contao 4.8.4 with single and multi edit.