### PR TITLE
Hotfix for replace constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ http://de.contaowiki.org/MultiColumnWizard
 
 ## Install
 
-You can install the Multicolumnwizard via the Contao-Manager - search for `contao-multicolumnwizard-bundle` - or with the Composer via the call
+The Multicolumnwizard is usually installed via an extension. If it is necessary to install Multicolumnwizard yourself, please use the console with the composer via the call
 
 `composer require menatwork/contao-multicolumnwizard-bundle`
+
 or
+
 `web/contao-manager.phar.php composer require menatwork/contao-multicolumnwizard-bundle`
 
-Developers can add the Multicolumnwizard to their `composer.json` as a dependent package.
+Developers should add the Multicolumnwizard to their `composer.json` as a dependent package.
 
 ## Usages
 

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
   },
   "replace": {
     "contao-legacy/multicolumnwizard": "*",
-    "menatwork/contao-multicolumnwizard": "self.version"
+    "menatwork/contao-multicolumnwizard": ">=3.3.4 <3.4.0"
   },
   "extra": {
     "contao-manager-plugin": "MenAtWork\\MultiColumnWizardBundle\\ContaoManager\\Plugin",


### PR DESCRIPTION
This fix should solve a problem where the bundle couldn't replace the older mcw extension. 