### PR TITLE
Convert binary UUIDs for DC_File driver

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -38,6 +38,7 @@
  * @author     w3scout <info@w3scouts.com>
  * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
  * @author     Andreas Dziemba <adziemba@web.de>
+ * @author     Daniele Sciannimanica <daniele@oveleon.de>
  * @copyright  2011 Andreas Schempp
  * @copyright  2011 certo web & design GmbH
  * @copyright  2013-2020 MEN AT WORK

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -38,7 +38,7 @@
  * @author     w3scout <info@w3scouts.com>
  * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
  * @author     Andreas Dziemba <adziemba@web.de>
- * @author     Daniele Sciannimanica <daniele@oveleon.de>
+ * @author     doishub <daniele@oveleon.de>
  * @copyright  2011 Andreas Schempp
  * @copyright  2011 certo web & design GmbH
  * @copyright  2013-2020 MEN AT WORK

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -587,16 +587,13 @@ class MultiColumnWizard extends Widget
                 }
 
                 // Convert binary UUIDs for DC_File driver (see contao#6893)
-                if ($arrField['inputType'] == 'fileTree' && 'DC_' . $GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] === \DC_File::class)
-                {
+                if ($arrField['inputType'] == 'fileTree'
+                    && 'DC_' . $GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] === \DC_File::class) {
                     $varValue = StringUtil::deserialize($varValue);
 
-                    if (!\is_array($varValue))
-                    {
+                    if (!\is_array($varValue)) {
                         $varValue = StringUtil::binToUuid($varValue);
-                    }
-                    else
-                    {
+                    } else {
                         $varValue = serialize(array_map('StringUtil::binToUuid', $varValue));
                     }
                 }

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -586,6 +586,21 @@ class MultiColumnWizard extends Widget
                     }
                 }
 
+                // Convert binary UUIDs for DC_File driver (see contao#6893)
+                if ($arrField['inputType'] == 'fileTree' && 'DC_' . $GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] === \DC_File::class)
+                {
+                    $varValue = StringUtil::deserialize($varValue);
+
+                    if (!\is_array($varValue))
+                    {
+                        $varValue = StringUtil::binToUuid($varValue);
+                    }
+                    else
+                    {
+                        $varValue = serialize(array_map('StringUtil::binToUuid', $varValue));
+                    }
+                }
+
                 $varInput[$i][$strKey] = $varValue;
 
                 // Do not submit if there are errors


### PR DESCRIPTION
When the widget is used within the `DC_File` driver, there is a problem when saving binary values. This means that binary values cannot be read afterwards.

This PR converts the binary UUIDs again after saving, as long as the `inputType` `fileTree` and `DC_File` driver is used. 

See also:
https://github.com/contao/contao/blob/d381a110efbc704e9793e229e98a9c0dffd16717/core-bundle/src/Resources/contao/drivers/DC_File.php#L381-L394

I am not sure if the integration has been done in the correct place.