### PR TITLE
Fix generateLabel when using columnsCallback

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -17,6 +17,8 @@ mapping:
     - "unknown <David.Maack@.men-at-work.de>"
   'Ingolf Steinhardt <info@e-spin.de>':
     - 'zonky2 <info@e-spin.de>'
+  "Fritz Michael Gschwantner <fmg@inspiredminds.at>":
+    - "fritzmg <fmg@inspiredminds.at>"
 
 copy-left:
  

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -38,6 +38,7 @@
  * @author     w3scout <info@w3scouts.com>
  * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
  * @author     Andreas Dziemba <adziemba@web.de>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @copyright  2011 Andreas Schempp
  * @copyright  2011 certo web & design GmbH
  * @copyright  2013-2020 MEN AT WORK

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -312,6 +312,11 @@ class MultiColumnWizard extends Widget
      */
     public function generateLabel()
     {
+        if (is_array($this->arrCallback)) {
+            $this->import($this->arrCallback[0]);
+            $this->columnFields = $this->{$this->arrCallback[0]}->{$this->arrCallback[1]}($this);
+        }
+
         foreach ($this->columnFields as $arrField) {
             if ($arrField['eval']['mandatory']) {
                 $this->addAttribute('mandatory', true);


### PR DESCRIPTION
#95 introduced the following problem: Contao's `be_widget` template calls `Widget::generateLabel` before `Widget::generateWithError` (wich then calls `Widget::generate`). However, currently only `MultiColumnWizard::generate` executes the `columnsCallback`. If your DCA _only_ uses the `columnsCallback` and does not define any columns for the MCW directly, then there are two problems:

* A warning will occur (visible in the debug mode): `Warning: Invalid argument supplied for foreach() at MultiColumnWizard.php:320`, since `$this->columnFields` will be `null`.
* Since `$this->columnFields` will be `null`, `MultiColumnWizard::generateLabel` will have no information about the used columns and thus cannot adjust the `mandatory` attribute.

This PR adds the callback execution to `MultiColumnWizard::generateLabel` as well. However, there is a drawback: now the callback is executed twice for each MCW widget. Once for `generateLabel` and once for `generateWithError`.