### PR TITLE
Fix misaligned table headers when using hideHead for some columns

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -17,6 +17,8 @@ mapping:
     - "unknown <David.Maack@.men-at-work.de>"
   'Ingolf Steinhardt <info@e-spin.de>':
     - 'zonky2 <info@e-spin.de>'
+  "Fritz Michael Gschwantner <fmg@inspiredminds.at>":
+    - "fritzmg <fmg@inspiredminds.at>"
 
 copy-left:
  

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -38,6 +38,7 @@
  * @author     w3scout <info@w3scouts.com>
  * @author     Yanick Witschi <yanick.witschi@terminal42.ch>
  * @author     Andreas Dziemba <adziemba@web.de>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @copyright  2011 Andreas Schempp
  * @copyright  2011 certo web & design GmbH
  * @copyright  2013-2020 MEN AT WORK

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -1328,41 +1328,41 @@ class MultiColumnWizard extends Widget
         $return = '';
 
         if ($onlyRows == false) {
-            // Generate header fields.
-            foreach ($this->columnFields as $strKey => $arrField) {
-                if ($arrField['eval']['columnPos']) {
-                    $arrHeaderItems[$arrField['eval']['columnPos']] = '<th></th>';
-                } else {
-                    $strHeaderItem = (key_exists($strKey, $arrHiddenHeader)) ? '<th class="hidden">' : '<th>';
+            // Generate header fields if not all are hidden.
+            if (count($this->columnFields) !== count($arrHiddenHeader)) {
+                foreach ($this->columnFields as $strKey => $arrField) {
+                    if ($arrField['eval']['columnPos']) {
+                        $arrHeaderItems[$arrField['eval']['columnPos']] = '<th></th>';
+                    } else {
+                        $strHeaderItem = '<th>' . (key_exists($strKey, $arrHiddenHeader) ? '<div class="hidden">' : '');
+                        if ($arrField['eval']['mandatory']) {
+                            $strHeaderItem .= '<span class="invisible">'
+                            . $GLOBALS['TL_LANG']['MSC']['mandatory']
+                            . ' </span>';
+                        }
+                        $strHeaderItem .=
+                        (
+                            (is_array($arrField['label']))
+                                ? $arrField['label'][0]
+                                : (
+                                    ($arrField['label'] != null)
+                                        ? $arrField['label']
+                                        : $strKey
+                                )
+                        );
+                        if ($arrField['eval']['mandatory']) {
+                            $strHeaderItem .= '<span class="mandatory">*</span>';
+                        }
+                        $strHeaderItem .=
+                        (
+                            (is_array($arrField['label']) && $arrField['label'][1] != '')
+                                ? '<span title="' . $arrField['label'][1] . '"><sup>(?)</sup></span>'
+                                : ''
+                        );
+                        $strHeaderItem .= (key_exists($strKey, $arrHiddenHeader)) ? '</div>' : '';
 
-                    $strHeaderItem .= (key_exists($strKey, $arrHiddenHeader)) ? '<div class="hidden">' : '';
-                    if ($arrField['eval']['mandatory']) {
-                        $strHeaderItem .= '<span class="invisible">'
-                        . $GLOBALS['TL_LANG']['MSC']['mandatory']
-                        . ' </span>';
+                        $arrHeaderItems[] = $strHeaderItem . '</th>';
                     }
-                    $strHeaderItem .=
-                    (
-                        (is_array($arrField['label']))
-                            ? $arrField['label'][0]
-                            : (
-                                ($arrField['label'] != null)
-                                    ? $arrField['label']
-                                    : $strKey
-                              )
-                    );
-                    if ($arrField['eval']['mandatory']) {
-                        $strHeaderItem .= '<span class="mandatory">*</span>';
-                    }
-                    $strHeaderItem .=
-                    (
-                        (is_array($arrField['label']) && $arrField['label'][1] != '')
-                            ? '<span title="' . $arrField['label'][1] . '"><sup>(?)</sup></span>'
-                            : ''
-                    );
-                    $strHeaderItem .= (key_exists($strKey, $arrHiddenHeader)) ? '</div>' : '';
-
-                    $arrHeaderItems[] = $strHeaderItem . '</th>';
                 }
             }
 


### PR DESCRIPTION
If only you only enable `hideHead` for some of the columns of the MCW widget, the table layout will be broken, since the `hidden` class on the `<th>` removes that `<th>` completely. Example:

<img src="https://user-images.githubusercontent.com/4970961/107884338-5dcd3980-6eec-11eb-85a6-80feb24b3f5f.png" width="714">

The table headers are aligned with the wrong columns, since `hideHead` is enabled for the first two columns (checkbox and name), but not for the other 3 columns. Since the CSS class `hidden` is added onto the `<th>` of these columns, those header table cells are removed completely and thus misaligned.

This PR changes that, so that the `hidden` class is only added to the child `<div>` and not the `<th>` table header cell itself. Additionally it checks whether all column headers are set to `hideHead` and then renders no `<thead>` whatsoever.
