### PR TITLE
Fix illegal array access

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -789,7 +789,7 @@ class MultiColumnWizard extends Widget
                     $arrField = array_merge($arrField, $this->arrRowSpecificData[$i][$strKey]);
                 }
 
-                $objWidget = $this->initializeWidget($arrField, $i, $strKey, $this->varValue[$i][$strKey]);
+                $objWidget = $this->initializeWidget($arrField, $i, $strKey, $this->varValue[$i][$strKey] ?? null);
 
                 // load errors if there are any
                 if (!empty($this->arrWidgetErrors[$strKey][$i])) {


### PR DESCRIPTION
Fixes an illegal array access that can occur in `MultiColumnWizard::generate`:

```
ErrorException:
Warning: Illegal string offset 'form'

  at vendor\menatwork\contao-multicolumnwizard-bundle\src\Contao\Widgets\MultiColumnWizard.php:792
  at MenAtWork\MultiColumnWizardBundle\Contao\Widgets\MultiColumnWizard->generate()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:651)
```