### PR TITLE
Load corret widget by using correct input type

### DIFF
--- a/src/EventListener/Mcw/CreateWidget.php
+++ b/src/EventListener/Mcw/CreateWidget.php
@@ -73,9 +73,11 @@ class CreateWidget
             );
             throw new BadRequestHttpException('Bad request');
         }
+        
+        $inputType = $GLOBALS['TL_DCA'][$dcDriver->table]['fields'][$fieldName]['inputType'];
 
         /** @var string $widgetClassName */
-        $widgetClassName = $GLOBALS['BE_FFL']['multiColumnWizard'];
+        $widgetClassName = $GLOBALS['BE_FFL'][$inputType];
 
         /** @var MultiColumnWizard $widget */
         $widget = new $widgetClassName(


### PR DESCRIPTION
Imagine you create a new widget by extending the MCW:

```php
class MyWidget extends MultiColumnWizard
{
    public function __construct($attributes = false)
    {
        parent::__construct($attributes);

        $this->columnFields = [
           // ...
        ];

        $this->disableSorting = true;
    }
}
```

The event listener will not load the correct widget. This PR fixes the behaviour by using the input Type defined within the DCA.