### PR TITLE
Fix erroneous composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "source": "https://github.com/menatwork/MultiColumnWizard"
   },
   "require": {
-    "php": "^5.6 || ^7.0" || ^8.0",
+    "php": "^5.6 || ^7.0 || ^8.0",
     "contao/core-bundle": "^4.9",
     "symfony/config": "^4.4 || ^5.1",
     "symfony/console": "^4.4 || ^5.1",


### PR DESCRIPTION
https://github.com/menatwork/contao-multicolumnwizard-bundle/commit/969bfc80d1e862beb41d972ceeb39ca593f70e65 introduced a syntax error in the composer.json. 