### PR TITLE
Add PHP8 array isset checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "source": "https://github.com/menatwork/MultiColumnWizard"
   },
   "require": {
-    "php": "^5.6 || ^7.0 || ^8.0",
+    "php": "^7.0 || ^8.0",
     "contao/core-bundle": "^4.9",
     "symfony/config": "^4.4 || ^5.1",
     "symfony/console": "^4.4 || ^5.1",

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -358,7 +358,7 @@ class MultiColumnWizard extends Widget
     public function generateLabel()
     {
         foreach ($this->columnFields as $arrField) {
-            if ($arrField['eval']['mandatory']) {
+            if (isset($arrField['eval']['mandatory']) && $arrField['eval']['mandatory']) {
                 $this->addAttribute('mandatory', true);
                 break;
             }
@@ -421,7 +421,7 @@ class MultiColumnWizard extends Widget
         $tableName = null
     ) {
         // Datepicker
-        if (!$fieldConfiguration['eval']['datepicker'] || !isset($fieldConfiguration['eval']['rgxp'])) {
+        if ((isset($fieldConfiguration['eval']['datepicker']) && !$fieldConfiguration['eval']['datepicker']) || !isset($fieldConfiguration['eval']['rgxp'])) {
             return '';
         }
 
@@ -720,22 +720,22 @@ class MultiColumnWizard extends Widget
 
         foreach ($this->columnFields as $strKey => $arrField) {
             // Store unique fields
-            if ($arrField['eval']['unique']) {
+            if (isset($arrField['eval']['unique']) && $arrField['eval']['unique']) {
                 $arrUnique[] = $strKey;
             }
 
             // Store date picker fields
-            if ($arrField['eval']['datepicker']) {
+            if (isset ($arrField['eval']['datepicker']) && $arrField['eval']['datepicker']) {
                 $arrDatepicker[] = $strKey;
             }
 
             // Store color picker fields
-            if ($arrField['eval']['colorpicker']) {
+            if (isset($arrField['eval']['colorpicker']) && $arrField['eval']['colorpicker']) {
                 $arrColorpicker[] = $strKey;
             }
 
             // Store tiny mce fields
-            if ($arrField['eval']['rte'] && strncmp($arrField['eval']['rte'], 'tiny', 4) === 0) {
+            if (isset($arrField['eval']['rte']) && $arrField['eval']['rte'] && strncmp($arrField['eval']['rte'], 'tiny', 4) === 0) {
                 foreach ($this->varValue as $row => $value) {
                     $tinyId = 'ctrl_' . $this->strField . '_row' . $row . '_' . $strKey;
 
@@ -781,7 +781,7 @@ class MultiColumnWizard extends Widget
                 $strWidget     = '';
                 $blnHiddenBody = false;
 
-                if ($arrField['eval']['hideHead'] == true) {
+                if (isset($arrField['eval']['hideHead']) && $arrField['eval']['hideHead'] == true) {
                     $arrHiddenHeader[$strKey] = true;
                 }
 
@@ -832,7 +832,7 @@ class MultiColumnWizard extends Widget
                 } elseif ($arrField['inputType'] == 'hidden') {
                     $strHidden .= $objWidget->generate();
                     continue;
-                } elseif ($arrField['eval']['hideBody'] == true || $arrField['eval']['hideHead'] == true) {
+                } elseif ((isset($arrField['eval']['hideBody']) && $arrField['eval']['hideBody'] == true) || (isset($arrField['eval']['hideHead']) && $arrField['eval']['hideHead'] == true)) {
                     if ($arrField['eval']['hideBody'] == true) {
                         $blnHiddenBody = true;
                     }
@@ -859,7 +859,7 @@ class MultiColumnWizard extends Widget
                     );
 
                     // Tiny MCE.
-                    if ($arrField['eval']['rte'] && strncmp($arrField['eval']['rte'], 'tiny', 4) === 0) {
+                    if (isset($arrField['eval']['rte']) && $arrField['eval']['rte'] && strncmp($arrField['eval']['rte'], 'tiny', 4) === 0) {
                         $additionalCode['tinyMce'] = $this->getMcWTinyMCEString(
                             $objWidget->id,
                             $arrField,
@@ -906,7 +906,7 @@ class MultiColumnWizard extends Widget
                 }
 
                 // Build array of items
-                if ($arrField['eval']['columnPos'] != '') {
+                if (isset($arrField['eval']['columnPos']) && $arrField['eval']['columnPos'] != '') {
                     $arrItems[$i][$objWidget->columnPos]['entry']   .= $strWidget;
                     $arrItems[$i][$objWidget->columnPos]['valign']   = $arrField['eval']['valign'];
                     $arrItems[$i][$objWidget->columnPos]['tl_class'] = $arrField['eval']['tl_class'];
@@ -915,7 +915,7 @@ class MultiColumnWizard extends Widget
                     $arrItems[$i][$strKey] = array
                     (
                         'entry'    => $strWidget,
-                        'valign'   => $arrField['eval']['valign'],
+                        'valign'   => $arrField['eval']['valign'] ?? null,
                         'tl_class' => $arrField['eval']['tl_class'],
                         'hide'     => $blnHiddenBody
                     );
@@ -1009,7 +1009,7 @@ class MultiColumnWizard extends Widget
         }
 
         // Add the help wizard
-        if ($arrField['eval']['helpwizard']) {
+        if (isset($arrField['eval']['helpwizard']) && $arrField['eval']['helpwizard']) {
             $xlabel .= ' <a href="contao/help.php?table=' . $this->strTable . '&amp;field=' . $this->strField
                 . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizard'])
                 . '" onclick="Backend.openModalIframe({\'width\':735,\'height\':405,\'title\':\''
@@ -1093,7 +1093,7 @@ class MultiColumnWizard extends Widget
         }
 
         // Input field callback
-        if (is_array($arrField['input_field_callback'])) {
+        if (isset($arrField['input_field_callback']) && is_array($arrField['input_field_callback'])) {
             if (!is_object($this->{$arrField['input_field_callback'][0]})) {
                 $this->import($arrField['input_field_callback'][0]);
             }
@@ -1125,12 +1125,12 @@ class MultiColumnWizard extends Widget
         }
 
         // Hide label except if multiple widgets are in one column
-        if ($arrField['eval']['columnPos'] == '') {
-            $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] . ' hidelabel');
+        if (isset($arrField['eval']['columnPos']) && $arrField['eval']['columnPos'] == '') {
+            $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] ?? '' . ' hidelabel');
         }
 
         // add class to enable easy updating of "name" attributes etc.
-        $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] . ' mcwUpdateFields');
+        $arrField['eval']['tl_class'] = trim($arrField['eval']['tl_class'] ?? '' . ' mcwUpdateFields');
 
         // if we have a row class, add that one aswell.
         if (isset($arrField['eval']['rowClasses'][$intRow])) {
@@ -1140,17 +1140,17 @@ class MultiColumnWizard extends Widget
         }
 
         // load callback
-        if (is_array($arrField['load_callback'])) {
+        if (isset($arrField['load_callback']) && is_array($arrField['load_callback'])) {
             foreach ($arrField['load_callback'] as $callback) {
                 $this->import($callback[0]);
                 $varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
             }
-        } elseif (is_callable($arrField['load_callback'])) {
+        } elseif (isset($arrField['load_callback']) && is_callable($arrField['load_callback'])) {
             $varValue = $arrField['load_callback']($varValue, $this);
         }
 
         // Convert date formats into timestamps (check the eval setting first -> #3063)
-        $rgxp               = $arrField['eval']['rgxp'];
+        $rgxp               = $arrField['eval']['rgxp'] ?? null;
         $dateFormatErrorMsg = '';
         if (($rgxp == 'date' || $rgxp == 'time' || $rgxp == 'datim') && $varValue != '') {
             try {
@@ -1171,7 +1171,7 @@ class MultiColumnWizard extends Widget
         $arrField['activeRow']         = $intRow;
         $arrField['name']              = $this->strName . '[' . $intRow . '][' . $strKey . ']';
         $arrField['id']                = $this->strId . '_row' . $intRow . '_' . $strKey;
-        $arrField['value']             = (null !== $varValue) ? $varValue : $arrField['default'];
+        $arrField['value']             = (null !== $varValue) ? $varValue : $arrField['default'] ?? null;
         $arrField['eval']['tableless'] = true;
 
         $arrData = $this->handleDcGeneral($arrField, $strKey);
@@ -1211,7 +1211,7 @@ class MultiColumnWizard extends Widget
             $arrData,
             $arrField['name'],
             $arrField['value'],
-            $arrField['strField'],
+            $arrField['strField'] ?? null,
             $this->strTable,
             $this
         ));
@@ -1387,10 +1387,10 @@ class MultiColumnWizard extends Widget
             // Generate header fields if not all are hidden.
             if (count($this->columnFields) !== count($arrHiddenHeader)) {
                 foreach ($this->columnFields as $strKey => $arrField) {
-                    if ($arrField['eval']['columnPos']) {
+                    if (isset($arrField['eval']['columnPos']) && $arrField['eval']['columnPos']) {
                         $arrHeaderItems[$arrField['eval']['columnPos']] = '<th></th>';
                     } else {
-                        if ((true === $arrField['eval']['hideBody']) && (true === $arrField['eval']['hideHead'])) {
+                        if ((isset($arrField['eval']['hideBody']) && true === $arrField['eval']['hideBody']) && (isset($arrField['eval']['hideHead']) && true === $arrField['eval']['hideHead'])) {
                             $strHeaderItem = (array_key_exists($strKey, $arrHiddenHeader))
                                 ? '<th class="hidden">'
                                 : '<th>';

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -1112,7 +1112,7 @@ class MultiColumnWizard extends Widget
         $arrField['eval']['required'] = false;
 
         // Use strlen() here (see #3277)
-        if ($arrField['eval']['mandatory']) {
+        if (isset($arrField['eval']['mandatory']) && $arrField['eval']['mandatory']) {
             if (is_array($this->varValue[$intRow][$strKey])) {
                 if (empty($this->varValue[$intRow][$strKey])) {
                     $arrField['eval']['required'] = true;
@@ -1398,7 +1398,7 @@ class MultiColumnWizard extends Widget
                             $strHeaderItem = '<th>'
                                 . (array_key_exists($strKey, $arrHiddenHeader) ? '<div class="hidden">' : '');
                         }
-                        if ($arrField['eval']['mandatory']) {
+                        if (isset($arrField['eval']['mandatory']) && $arrField['eval']['mandatory']) {
                             $strHeaderItem .= '<span class="invisible">'
                             . $GLOBALS['TL_LANG']['MSC']['mandatory']
                             . ' </span>';
@@ -1413,7 +1413,7 @@ class MultiColumnWizard extends Widget
                                         : $strKey
                                 )
                         );
-                        if ($arrField['eval']['mandatory']) {
+                        if (isset($arrField['eval']['mandatory']) && $arrField['eval']['mandatory']) {
                             $strHeaderItem .= '<span class="mandatory">*</span>';
                         }
                         $strHeaderItem   .=

--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -608,7 +608,7 @@ class MultiColumnWizard extends Widget
                 $varValue = $objWidget->value;
 
                 // Convert date formats into timestamps (check the eval setting first -> #3063)
-                $rgxp = $arrField['eval']['rgxp'];
+                $rgxp = $arrField['eval']['rgxp'] ?? '';
                 if (!$objWidget->hasErrors()
                     && ($rgxp == 'date' || $rgxp == 'time' || $rgxp == 'datim')
                     && $varValue != ''
@@ -618,7 +618,7 @@ class MultiColumnWizard extends Widget
                 }
 
                 // Save callback
-                if (is_array($arrField['save_callback'])) {
+                if (isset($arrField['save_callback']) && is_array($arrField['save_callback'])) {
                     foreach ($arrField['save_callback'] as $callback) {
                         $this->import($callback[0]);
 
@@ -1150,7 +1150,7 @@ class MultiColumnWizard extends Widget
         }
 
         // Convert date formats into timestamps (check the eval setting first -> #3063)
-        $rgxp               = $arrField['eval']['rgxp'] ?? null;
+        $rgxp               = $arrField['eval']['rgxp'] ?? '';
         $dateFormatErrorMsg = '';
         if (($rgxp == 'date' || $rgxp == 'time' || $rgxp == 'datim') && $varValue != '') {
             try {


### PR DESCRIPTION
Fixes some `undefined array key` warnings:

![image (2)](https://user-images.githubusercontent.com/754921/137877683-53d42659-0f98-436a-bf24-5299de042885.png)

Removed PHP 5.6 support (as this commit https://github.com/menatwork/contao-multicolumnwizard-bundle/commit/05d2917208d08f4fe63961bd4108d63a2c3f6420 introduced PHP 7 features)
