### PR TITLE
Support datacontainer from class name

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -51,6 +51,7 @@
 namespace MenAtWork\MultiColumnWizardBundle\Contao\Widgets;
 
 use Contao\BackendTemplate;
+use Contao\DataContainer;
 use Contao\Date;
 use Contao\Image;
 use Contao\Input;
@@ -539,7 +540,11 @@ class MultiColumnWizard extends Widget
      */
     public function getDcDriver()
     {
-        $dataContainer = 'DC_' . $GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'];
+        if (method_exists(DataContainer::class, 'getDriverForTable')) {
+            $dataContainer = DataContainer::getDriverForTable($this->strTable);
+        } else {
+            $dataContainer = 'DC_' . $GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'];
+        }
 
         if ($dataContainer == \DC_General::class) {
             $dcgXRequestTemp                  = $_SERVER['HTTP_X_REQUESTED_WITH'];


### PR DESCRIPTION
Contao switched to using FQCN in 4.9.28 (https://github.com/contao/contao/pull/4322). Since support was only added in 4.9.17 (https://github.com/contao/contao/pull/3179) I've added a `method_exists` check and fallback to the old logic.